### PR TITLE
SAMD core support

### DIFF
--- a/pgmStrToRAM.cpp
+++ b/pgmStrToRAM.cpp
@@ -1,5 +1,6 @@
 #include <avr/pgmspace.h>
 #include <stdlib.h>
+#include <string.h>
 
 char *to_print;
 char *pgmStrToRAM(PROGMEM char *theString) {


### PR DESCRIPTION
This adds an extra include to ```pgmStrToRAM.cpp``` to support [Arduino SAMD](https://github.com/arduino/ArduinoCore-samd) boards like the [Zero](http://www.arduino.cc/en/Main/ArduinoBoardZero) and [MKR1000](http://www.arduino.cc/en/Main/ArduinoMKR1000).